### PR TITLE
Using new get_parameters function (read desc) automatically search when a "?q=query" is provided.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,8 +7,8 @@ local domains = get("domain", true)
 
 local visible = false;
 
-query.on_submit(function(content)
-    if not visible then
+function searchQuery(content)
+ if not visible then
         print("turning shit visible....")
 
         for k,v in pairs(cards) do
@@ -37,6 +37,10 @@ query.on_submit(function(content)
         link.set_href("buss://" .. v["domain"])
         desc.set_content(v["description"])
     end
+end
+
+query.on_submit(function(query)
+   searchQuery(query)
 end)
 
 function percentage(value, min, max)

--- a/main.lua
+++ b/main.lua
@@ -40,10 +40,8 @@ function searchQuery(content)
 end
 
 local status,err = pcall(function()
-    print("TRYING TO DO SOME COOL PARAMETER BULLSHIT")
     local queryParameter = get_parameters()
     if queryParameter.q then
- print("FUCK YEAH!")
     query.set_content(queryParameter.q)
     searchQuery(queryParameter.q)
      end

--- a/main.lua
+++ b/main.lua
@@ -39,6 +39,14 @@ function searchQuery(content)
     end
 end
 
+local status,err = pcall(function()
+    local queryParameter = get_parameters()
+    if queryParameter.q then
+    query.set_content(queryParameter.q)
+    searchQuery(queryParameter.q)
+     end
+end)
+
 query.on_submit(function(query)
    searchQuery(query)
 end)

--- a/main.lua
+++ b/main.lua
@@ -40,8 +40,10 @@ function searchQuery(content)
 end
 
 local status,err = pcall(function()
+    print("TRYING TO DO SOME COOL PARAMETER BULLSHIT")
     local queryParameter = get_parameters()
     if queryParameter.q then
+ print("FUCK YEAH!")
     query.set_content(queryParameter.q)
     searchQuery(queryParameter.q)
      end


### PR DESCRIPTION
On newer clients with [this PR](https://github.com/face-hh/webx/pull/62) dingle.it can fill in the search field and browse for a term from the address bar